### PR TITLE
Add data to error response

### DIFF
--- a/client/toError.js
+++ b/client/toError.js
@@ -1,8 +1,8 @@
-const toError = ({ message, name, status, data }) => {
+const toError = ({ data, message, name, status }) => {
   const err = new Error(message)
+  err.data = data
   err.name = name
   err.status = status
-  err.data = data
   return err
 }
 

--- a/client/toError.js
+++ b/client/toError.js
@@ -1,7 +1,8 @@
-const toError = ({ message, name, status }) => {
+const toError = ({ message, name, status, data }) => {
   const err = new Error(message)
   err.name = name
   err.status = status
+  err.data = data
   return err
 }
 

--- a/server/fromError.js
+++ b/server/fromError.js
@@ -1,8 +1,8 @@
 const { boomify } = require('boom')
 const { path, pipe, prop, unless } = require('ramda')
 
-const formatError = ({ message, error: name, statusCode: status, data }) =>
-  ({ message, name, status, data })
+const formatError = ({ data, message, error: name, statusCode: status }) =>
+  ({ data, message, name, status })
 
 const fromError = pipe(
   unless(prop('isBoom'), boomify),

--- a/server/fromError.js
+++ b/server/fromError.js
@@ -1,8 +1,8 @@
 const { boomify } = require('boom')
 const { path, pipe, prop, unless } = require('ramda')
 
-const formatError = ({ message, error: name, statusCode: status }) =>
-  ({ message, name, status })
+const formatError = ({ message, error: name, statusCode: status, data }) =>
+  ({ message, name, status, data })
 
 const fromError = pipe(
   unless(prop('isBoom'), boomify),

--- a/test/handle.js
+++ b/test/handle.js
@@ -36,10 +36,10 @@ describe('handle', () => {
   }
 
   const handler = handle({
+    BAD_REQUEST: badRequest,
     GET_USER:  get,
     NOT_FOUND: notFound,
-    PUT_USER:  put,
-    BAD_REQUEST: badRequest
+    PUT_USER:  put
   })
 
   beforeEach(() =>
@@ -112,10 +112,10 @@ describe('handle', () => {
       expect(respond.calls[0][0]).to.eql({
         type: 'NOT_FOUND',
         payload: {
+          data: undefined,
           message: 'Not Found',
           name: 'Not Found',
           status: 404,
-          data: undefined,
         },
         error: true
       })
@@ -134,10 +134,10 @@ describe('handle', () => {
       expect(respond.calls[0][0]).to.eql({
         type: 'BAD_REQUEST',
         payload: {
+          data: { foo: 'bar' },
           message: 'Bad Request',
           name: 'Bad Request',
           status: 400,
-          data: { foo: 'bar' }
         },
         error: true
       })

--- a/test/handle.js
+++ b/test/handle.js
@@ -29,10 +29,17 @@ describe('handle', () => {
     throw Boom.notFound()
   }
 
+  const badRequest = () => {
+    const err = Boom.badRequest()
+    err.output.payload.data = { foo: 'bar' }
+    throw err
+  }
+
   const handler = handle({
     GET_USER:  get,
     NOT_FOUND: notFound,
-    PUT_USER:  put
+    PUT_USER:  put,
+    BAD_REQUEST: badRequest
   })
 
   beforeEach(() =>
@@ -107,7 +114,30 @@ describe('handle', () => {
         payload: {
           message: 'Not Found',
           name: 'Not Found',
-          status: 404
+          status: 404,
+          data: undefined,
+        },
+        error: true
+      })
+    )
+  })
+
+  describe('when it fails with data', () => {
+    const notFound = action('BAD_REQUEST', null)
+    const respond  = spy()
+
+    beforeEach(() =>
+      handler(notFound, respond)
+    )
+
+    it('responds with an error action', () =>
+      expect(respond.calls[0][0]).to.eql({
+        type: 'BAD_REQUEST',
+        payload: {
+          message: 'Bad Request',
+          name: 'Bad Request',
+          status: 400,
+          data: { foo: 'bar' }
         },
         error: true
       })


### PR DESCRIPTION
Allow additional information to be added to an error response via a new `data` property on the boom object's payload.