### PR TITLE
Add unlock

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "postversion": "git push --tags origin master",
     "prebuild": "yarn run clean",
     "pretest": "yarn run build",
-    "pretest:coverage": "yarn run build",
     "preversion": "git checkout master && yarn run build",
     "test": "mocha test --reporter=dot",
     "test:ci": "yarn run lint && yarn run test:coverage && yarn run coverage",
@@ -30,7 +29,7 @@
   },
   "dependencies": {
     "@articulate/ducks": "^0.1.0",
-    "@articulate/funky": "^0.1.0",
+    "@articulate/funky": "^0.3.0",
     "boom": "^5.2.0",
     "crocks": "^0.8.1",
     "cuid": "^1.3.8",

--- a/server/index.js
+++ b/server/index.js
@@ -2,5 +2,6 @@ module.exports = (opts={}) => ({
   handle: require('./handle')(opts),
   join:   require('./join'),
   leave:  require('./leave'),
-  to:     require('./to')
+  to:     require('./to'),
+  unlock: require('./unlock')
 })

--- a/server/unlock.js
+++ b/server/unlock.js
@@ -1,0 +1,14 @@
+const {
+  compose, curry, flip, map, nAry, once, partial, pipeP
+} = require('ramda')
+
+const { promisify, tapP } = require('@articulate/funky')
+
+// unlock : Socket -> [ Function ] -> a -> Promise a
+const unlock = (socket, middleware) => {
+  const convert = compose(nAry(0), flip(partial)([ socket ]), promisify)
+
+  return tapP(once(pipeP(...map(convert, middleware))))
+}
+
+module.exports = curry(unlock)

--- a/server/unlock.js
+++ b/server/unlock.js
@@ -4,7 +4,7 @@ const {
 
 const { promisify, tapP } = require('@articulate/funky')
 
-// unlock : Socket -> [ Function ] -> a -> Promise a
+// unlock :: Socket -> [ Function ] -> a -> Promise a
 const unlock = (socket, middleware) => {
   const convert = compose(nAry(0), flip(partial)([ socket ]), promisify)
 

--- a/test/unlock.js
+++ b/test/unlock.js
@@ -22,7 +22,7 @@ describe('unlock', () => {
     next(new Error('broke'))
   }
 
-  const brokeThrown = (socket, next) => {
+  const brokeThrown = () => {
     throw new Error('broke')
   }
 

--- a/test/unlock.js
+++ b/test/unlock.js
@@ -1,0 +1,78 @@
+const { expect } = require('chai')
+const property   = require('prop-factory')
+const spy        = require('@articulate/spy')
+
+const { unlock } = require('..')()
+
+describe('unlock', () => {
+  const res    = property()
+  const socket = { on: spy() }
+
+  const foo = (socket, next) => {
+    socket.on('foo', Function.prototype)
+    next()
+  }
+
+  const bar = (socket, next) => {
+    socket.on('bar', Function.prototype)
+    next()
+  }
+
+  const brokeCallback = (socket, next) => {
+    next(new Error('broke'))
+  }
+
+  const brokeThrown = (socket, next) => {
+    throw new Error('broke')
+  }
+
+  afterEach(() => {
+    res(undefined)
+    socket.on.reset()
+  })
+
+  describe('when secure middlewares work', () => {
+    beforeEach(() =>
+      Promise.resolve('blah')
+        .then(unlock(socket, [ foo, bar ]))
+        .then(res)
+    )
+
+    it('unlocks the middlewares', () => {
+      expect(socket.on.calls[0][0]).to.equal('foo')
+      expect(socket.on.calls[1][0]).to.equal('bar')
+    })
+
+    it('taps to pass-thru', () =>
+      expect(res()).to.equal('blah')
+    )
+  })
+
+  describe('when middlewares fail by callback', () => {
+    beforeEach(() =>
+      Promise.resolve('blah')
+        .then(unlock(socket, [ foo, brokeCallback, bar ]))
+        .catch(res)
+    )
+
+    it('rejects correctly', () => {
+      expect(socket.on.calls.length).to.equal(1)
+      expect(socket.on.calls[0][0]).to.equal('foo')
+      expect(res()).to.be.an('error')
+    })
+  })
+
+  describe('when middlewares fail by throw', () => {
+    beforeEach(() =>
+      Promise.resolve('blah')
+        .then(unlock(socket, [ foo, brokeThrown, bar ]))
+        .catch(res)
+    )
+
+    it('rejects correctly', () => {
+      expect(socket.on.calls.length).to.equal(1)
+      expect(socket.on.calls[0][0]).to.equal('foo')
+      expect(res()).to.be.an('error')
+    })
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -8,9 +8,9 @@
   dependencies:
     crocks "^0.7.0"
 
-"@articulate/funky@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@articulate/funky/-/funky-0.1.0.tgz#d7dc756f62b1f66ba703d13e101e7ae510b625f8"
+"@articulate/funky@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@articulate/funky/-/funky-0.3.0.tgz#73840a385c00e296c413aa75821fe5279a1207af"
   dependencies:
     joi "^10.6.0"
     ramda "^0.24.1"


### PR DESCRIPTION
![dilbert](https://i.pinimg.com/736x/34/75/b7/3475b7139d26733e69c60053bcd70265--scott-adams-lwren-scott.jpg)

There were Dilbert's with the word "unlock" actually in them, but this one was much better.

It would be nice to keep our existing socket.io middleware, but also to start authenticating by a socket action, rather than with a cookie in the handshake.  That means we can't unlock access to the restricted socket actions until after we receive and verify the user's token.  And if we don't ever call `next()` in the authentication middleware, then the client never thinks it is connected.  :sigh:

So I'm adding `unlock`, which will make that much easier.  See the updated docs for an example.