### PR TITLE
Fix errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: node_js
 node_js:
   - '8'
-  - '7'
-  - '6'
 before_install:
-  - npm install -g yarn@1.3.2
+  - npm install -g yarn@1.7.0
 install:
   - yarn install --pure-lockfile
 script:

--- a/package.json
+++ b/package.json
@@ -29,12 +29,12 @@
   },
   "dependencies": {
     "@articulate/ducks": "^0.1.0",
-    "@articulate/funky": "^0.3.0",
-    "boom": "^5.2.0",
-    "crocks": "^0.8.1",
-    "cuid": "^1.3.8",
+    "@articulate/funky": "^1.0.1",
+    "boom": "^7.2.0",
+    "crocks": "^0.9.3",
+    "cuid": "^2.1.1",
     "ramda": "^0.25.0",
-    "socket.io-client": "^2.0.4"
+    "socket.io-client": "^2.1.1"
   },
   "devDependencies": {
     "@articulate/spy": "^0.0.1",
@@ -42,7 +42,7 @@
     "chai": "^4.1.2",
     "coveralls": "^3.0.0",
     "eslint": "^4.11.0",
-    "joi": "12",
+    "joi": "^13.3.0",
     "mocha": "^4.0.1",
     "nyc": "^11.3.0",
     "prop-factory": "^1.0.0"

--- a/server/fromError.js
+++ b/server/fromError.js
@@ -1,8 +1,20 @@
 const { boomify, badRequest } = require('boom')
-const { converge, identity, path, pipe, prop, unless, when } = require('ramda')
+const { converge, identity, pipe, prop, unless, when } = require('ramda')
 
-const formatError = ({ data, message, error: name, statusCode: status }) =>
-  ({ data, message, name, status })
+const formatError = err => {
+  const {
+    message,
+    output: {
+      payload: {
+        data,
+        error: name,
+        statusCode: status
+      }
+    }
+  } = err
+
+  return { data, message, name, status }
+}
 
 const joiError = pipe(
   prop('details'),
@@ -12,7 +24,6 @@ const joiError = pipe(
 const fromError = pipe(
   when(prop('isJoi'), joiError),
   unless(prop('isBoom'), boomify),
-  path(['output', 'payload']),
   formatError
 )
 

--- a/test/handle.js
+++ b/test/handle.js
@@ -39,7 +39,7 @@ describe('handle', () => {
   }
 
   const horribleError = () => {
-    throw new Error('foobar')
+    throw new Error('Some horrible error')
   }
 
   const joiError = () => {
@@ -186,7 +186,7 @@ describe('handle', () => {
         type: 'HORRIBLE_ERROR',
         payload: {
           data: undefined,
-          message: 'An internal server error occurred',
+          message: 'Some horrible error',
           name: 'Internal Server Error',
           status: 500,
         },
@@ -196,7 +196,7 @@ describe('handle', () => {
       expect(console.error.calls[0].length).to.equal(1)
       const err = JSON.parse(console.error.calls[0][0])
       expect(err).to.have.property('name', 'Error')
-      expect(err).to.have.property('message', 'foobar')
+      expect(err).to.have.property('message', 'Some horrible error')
       expect(err).to.have.property('stack').that.is.a('string')
     })
   })

--- a/test/handle.js
+++ b/test/handle.js
@@ -1,9 +1,10 @@
-const { action } = require('@articulate/ducks')
-const Boom       = require('boom')
-const { expect } = require('chai')
-const property   = require('prop-factory')
-const spy        = require('@articulate/spy')
-const Joi        = require('joi')
+const { action }   = require('@articulate/ducks')
+const Boom         = require('boom')
+const { expect }   = require('chai')
+const property     = require('prop-factory')
+const spy          = require('@articulate/spy')
+const Joi          = require('joi')
+const { validate } = require('@articulate/funky')
 
 const { assoc, curry } = require('ramda')
 
@@ -42,9 +43,11 @@ describe('handle', () => {
     throw new Error('Some horrible error')
   }
 
-  const joiError = () => {
-    throw Joi.validate({}, Joi.object({ foo: Joi.string().required() })).error
-  }
+  const schema = Joi.object({
+    foo: Joi.string().required()
+  }).required()
+
+  const joiError = validate(schema)
 
   const handler = handle({
     BAD_REQUEST: badRequest,
@@ -202,7 +205,7 @@ describe('handle', () => {
   })
 
   describe('when it fails with a joi error', () => {
-    const joiError = action('JOI_ERROR', null)
+    const joiError = action('JOI_ERROR', {})
     const respond  = spy()
 
     beforeEach(() =>

--- a/yarn.lock
+++ b/yarn.lock
@@ -8,12 +8,11 @@
   dependencies:
     crocks "^0.7.0"
 
-"@articulate/funky@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@articulate/funky/-/funky-0.3.0.tgz#73840a385c00e296c413aa75821fe5279a1207af"
+"@articulate/funky@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@articulate/funky/-/funky-1.0.1.tgz#f54c6d18d259a091b85cafdde4229f2b50ca4547"
   dependencies:
-    joi "^10.6.0"
-    ramda "^0.24.1"
+    ramda "^0.25.0"
 
 "@articulate/spy@^0.0.1":
   version "0.0.1"
@@ -275,11 +274,17 @@ boom@4.x.x:
   dependencies:
     hoek "4.x.x"
 
-boom@5.x.x, boom@^5.2.0:
+boom@5.x.x:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/boom/-/boom-5.2.0.tgz#5dd9da6ee3a5f302077436290cb717d3f4a54e02"
   dependencies:
     hoek "4.x.x"
+
+boom@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/boom/-/boom-7.2.0.tgz#2bff24a55565767fde869ec808317eb10c48e966"
+  dependencies:
+    hoek "5.x.x"
 
 brace-expansion@^1.1.7:
   version "1.1.8"
@@ -295,10 +300,6 @@ braces@^1.8.2:
     expand-range "^1.8.1"
     preserve "^0.2.0"
     repeat-element "^1.1.2"
-
-browser-fingerprint@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/browser-fingerprint/-/browser-fingerprint-0.0.1.tgz#8df3cdca25bf7d5b3542d61545d730053fce604a"
 
 browser-stdout@1.3.0:
   version "1.3.0"
@@ -489,10 +490,6 @@ convert-source-map@^1.3.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.0.tgz#9acd70851c6d5dfdd93d9282e5edf94a03ff46b5"
 
-core-js@^1.1.1:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
-
 core-js@^2.4.0:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.1.tgz#ae6874dc66937789b80754ff5428df66819ca50b"
@@ -515,9 +512,9 @@ crocks@^0.7.0:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/crocks/-/crocks-0.7.1.tgz#d27d52153ab0f40f076fe3bc8efcee41c212d8f8"
 
-crocks@^0.8.1:
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/crocks/-/crocks-0.8.1.tgz#d85a35141ee2e9dfd31d16f60f596091f9c967b4"
+crocks@^0.9.3:
+  version "0.9.3"
+  resolved "https://registry.yarnpkg.com/crocks/-/crocks-0.9.3.tgz#7f084ace9c0793092d34e96949bca922fdf8c289"
 
 cross-spawn@^4:
   version "4.0.2"
@@ -540,13 +537,9 @@ cryptiles@3.x.x:
   dependencies:
     boom "5.x.x"
 
-cuid@^1.3.8:
-  version "1.3.8"
-  resolved "https://registry.yarnpkg.com/cuid/-/cuid-1.3.8.tgz#4b875e0969bad764f7ec0706cf44f5fb0831f6b7"
-  dependencies:
-    browser-fingerprint "0.0.1"
-    core-js "^1.1.1"
-    node-fingerprint "0.0.2"
+cuid@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/cuid/-/cuid-2.1.1.tgz#3b0fccbda1089ff123a127320c860b975200d62b"
 
 dashdash@^1.12.0:
   version "1.14.1"
@@ -558,13 +551,13 @@ debug-log@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debug-log/-/debug-log-1.0.1.tgz#2307632d4c04382b8df8a32f70b895046d52745f"
 
-debug@3.1.0, debug@^3.0.1, debug@^3.1.0:
+debug@3.1.0, debug@^3.0.1, debug@^3.1.0, debug@~3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   dependencies:
     ms "2.0.0"
 
-debug@^2.6.8, debug@~2.6.4, debug@~2.6.9:
+debug@^2.6.8:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
@@ -629,13 +622,13 @@ ecc-jsbn@~0.1.1:
   dependencies:
     jsbn "~0.1.0"
 
-engine.io-client@~3.1.0:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/engine.io-client/-/engine.io-client-3.1.4.tgz#4fcf1370b47163bd2ce9be2733972430350d4ea1"
+engine.io-client@~3.2.0:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/engine.io-client/-/engine.io-client-3.2.1.tgz#6f54c0475de487158a1a7c77d10178708b6add36"
   dependencies:
     component-emitter "1.2.1"
     component-inherit "0.0.3"
-    debug "~2.6.9"
+    debug "~3.1.0"
     engine.io-parser "~2.1.1"
     has-cors "1.1.0"
     indexof "0.0.1"
@@ -1025,6 +1018,10 @@ hoek@4.x.x:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-4.2.0.tgz#72d9d0754f7fe25ca2d01ad8f8f9a9449a89526d"
 
+hoek@5.x.x:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/hoek/-/hoek-5.0.3.tgz#b71d40d943d0a95da01956b547f83c4a5b4a34ac"
+
 hosted-git-info@^2.1.4:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.5.0.tgz#6d60e34b3abbc8313062c3b798ef8d901a07af3c"
@@ -1213,10 +1210,6 @@ isarray@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-2.0.1.tgz#a37d94ed9cda2d59865c9f76fe596ee1f338741e"
 
-isemail@2.x.x:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/isemail/-/isemail-2.2.1.tgz#0353d3d9a62951080c262c2aa0a42b8ea8e9e2a6"
-
 isemail@3.x.x:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/isemail/-/isemail-3.1.2.tgz#937cf919002077999a73ea8b1951d590e84e01dd"
@@ -1284,26 +1277,13 @@ istanbul-reports@^1.1.3:
   dependencies:
     handlebars "^4.0.3"
 
-items@2.x.x:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/items/-/items-2.1.1.tgz#8bd16d9c83b19529de5aea321acaada78364a198"
-
-joi@12:
-  version "12.0.0"
-  resolved "https://registry.yarnpkg.com/joi/-/joi-12.0.0.tgz#46f55e68f4d9628f01bbb695902c8b307ad8d33a"
+joi@^13.3.0:
+  version "13.3.0"
+  resolved "https://registry.yarnpkg.com/joi/-/joi-13.3.0.tgz#4defd4333b539c5d10e444ab44f5a5583480f17c"
   dependencies:
-    hoek "4.x.x"
+    hoek "5.x.x"
     isemail "3.x.x"
-    topo "2.x.x"
-
-joi@^10.6.0:
-  version "10.6.0"
-  resolved "https://registry.yarnpkg.com/joi/-/joi-10.6.0.tgz#52587f02d52b8b75cdb0c74f0b164a191a0e1fc2"
-  dependencies:
-    hoek "4.x.x"
-    isemail "2.x.x"
-    items "2.x.x"
-    topo "2.x.x"
+    topo "3.x.x"
 
 js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
@@ -1534,10 +1514,6 @@ mute-stream@0.0.7:
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
-
-node-fingerprint@0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/node-fingerprint/-/node-fingerprint-0.0.2.tgz#31cbabeb71a67ae7dd5a7dc042e51c3c75868501"
 
 normalize-package-data@^2.3.2:
   version "2.4.0"
@@ -1804,10 +1780,6 @@ qs@~6.5.1:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
 
-ramda@^0.24.1:
-  version "0.24.1"
-  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.24.1.tgz#c3b7755197f35b8dc3502228262c4c91ddb6b857"
-
 ramda@^0.25.0:
   version "0.25.0"
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.25.0.tgz#8fdf68231cffa90bc2f9460390a0cb74a29b29a9"
@@ -2001,31 +1973,31 @@ sntp@2.x.x:
   dependencies:
     hoek "4.x.x"
 
-socket.io-client@^2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/socket.io-client/-/socket.io-client-2.0.4.tgz#0918a552406dc5e540b380dcd97afc4a64332f8e"
+socket.io-client@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/socket.io-client/-/socket.io-client-2.1.1.tgz#dcb38103436ab4578ddb026638ae2f21b623671f"
   dependencies:
     backo2 "1.0.2"
     base64-arraybuffer "0.1.5"
     component-bind "1.0.0"
     component-emitter "1.2.1"
-    debug "~2.6.4"
-    engine.io-client "~3.1.0"
+    debug "~3.1.0"
+    engine.io-client "~3.2.0"
+    has-binary2 "~1.0.2"
     has-cors "1.1.0"
     indexof "0.0.1"
     object-component "0.0.3"
     parseqs "0.0.5"
     parseuri "0.0.5"
-    socket.io-parser "~3.1.1"
+    socket.io-parser "~3.2.0"
     to-array "0.1.4"
 
-socket.io-parser@~3.1.1:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-3.1.2.tgz#dbc2282151fc4faebbe40aeedc0772eba619f7f2"
+socket.io-parser@~3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/socket.io-parser/-/socket.io-parser-3.2.0.tgz#e7c6228b6aa1f814e6148aea325b51aa9499e077"
   dependencies:
     component-emitter "1.2.1"
-    debug "~2.6.4"
-    has-binary2 "~1.0.2"
+    debug "~3.1.0"
     isarray "2.0.1"
 
 source-map@^0.4.4:
@@ -2197,11 +2169,11 @@ to-fast-properties@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
 
-topo@2.x.x:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/topo/-/topo-2.0.2.tgz#cd5615752539057c0dc0491a621c3bc6fbe1d182"
+topo@3.x.x:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/topo/-/topo-3.0.0.tgz#37e48c330efeac784538e0acd3e62ca5e231fe7a"
   dependencies:
-    hoek "4.x.x"
+    hoek "5.x.x"
 
 tough-cookie@~2.3.3:
   version "2.3.3"


### PR DESCRIPTION
![dilbert errors](http://4.bp.blogspot.com/-NQf68JLQuYg/Vo6lHdmzEgI/AAAAAAAAAGo/g-U_4cpyT5Q/s640/Dilbert_ExcelErrors_20160107.gif)

In the past, `sox` has been less than helpful auto-wrapping vanilla errors with `Boom` representations.  They all just ended up as 500's, and the original message was lost in time and space.

Now we can surface those custom error messages.  You'll still get a 500, but the `message` property should be helpful.

## to test:
- [ ] Read the code.
- [ ] Wait for the green.
- [ ] Find a squirrel in sox.