### PR TITLE
Support timeout option

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -1,10 +1,10 @@
 const action  = require('@articulate/ducks/lib/action')
-const error   = require('@articulate/ducks/lib/error')
 const Async   = require('crocks/Async')
 const bind    = require('ramda/src/bind')
 const compose = require('ramda/src/compose')
 const cuid    = require('cuid')
 const curry   = require('ramda/src/curry')
+const error   = require('@articulate/ducks/lib/error')
 const evolve  = require('ramda/src/evolve')
 const io      = require('socket.io-client')
 const merge   = require('ramda/src/merge')
@@ -77,7 +77,7 @@ const sox = (args = {}) => {
   // send : String -> a -> Async Action
   socket.send = send
 
-  // send : Object -> String -> a -> Async Action
+  // sendWithOptions : { k: v } -> String -> a -> Async Action
   socket.sendWithOptions = sendWithOptions
 
   // session : String

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@articulate/ducks": "^0.1.0",
     "@articulate/funky": "^1.0.1",
     "boom": "^7.2.0",
-    "crocks": "^0.9.3",
+    "crocks": "^0.10.1",
     "cuid": "^2.1.1",
     "ramda": "^0.25.0",
     "socket.io-client": "^2.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -508,13 +508,13 @@ coveralls@^3.0.0:
     minimist "^1.2.0"
     request "^2.79.0"
 
+crocks@^0.10.1:
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/crocks/-/crocks-0.10.1.tgz#be545fe089aeba301cc75868aac82efc9c2b3245"
+
 crocks@^0.7.0:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/crocks/-/crocks-0.7.1.tgz#d27d52153ab0f40f076fe3bc8efcee41c212d8f8"
-
-crocks@^0.9.3:
-  version "0.9.3"
-  resolved "https://registry.yarnpkg.com/crocks/-/crocks-0.9.3.tgz#7f084ace9c0793092d34e96949bca922fdf8c289"
 
 cross-spawn@^4:
   version "4.0.2"


### PR DESCRIPTION
Add a new `sendWithOptions` function that accepts a timeout option. Reject with an error action if `send` does not resolve before the timeout.

This is intended to trigger an error when we expect an action from a socket but it never occurs, possibly because the service is down or there is a version mismatch between frontend & backend.