### PR TITLE
Add ability to pass options for the client on creation

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -22,7 +22,8 @@ const key = curry((type, payload) =>
 const sox = (args = {}) => {
   const {
     query = Function.prototype,
-    uri   = ''
+    uri   = '',
+    options = {}
   } = args
 
   const session = { session: cuid() }
@@ -35,7 +36,7 @@ const sox = (args = {}) => {
     query: merge(session, query())
   }
 
-  const socket = io(base, opts)
+  const socket = io(base, merge(options, opts))
 
   const connect = bind(socket.connect, socket)
 

--- a/client/index.js
+++ b/client/index.js
@@ -15,6 +15,17 @@ const debounce = require('./debounce')
 const throttle = require('./throttle')
 const toError  = require('./toError')
 
+const ALLOWED_OPTIONS = [
+  'randomizationFactor',
+  'reconnection',
+  'reconnectionAttempts',
+  'reconnectionDelay',
+  'reconnectionDelayMax',
+  'timeout',
+  'transports',
+  'upgrade'
+]
+
 const key = curry((type, payload) =>
   `${type}/${payload.id}`
 )
@@ -36,7 +47,8 @@ const sox = (args = {}) => {
     query: merge(session, query())
   }
 
-  const socket = io(base, merge(options, opts))
+  const getOptions = compose(merge(opts), pick(ALLOWED_OPTIONS))
+  const socket = io(base, getOptions(options))
 
   const connect = bind(socket.connect, socket)
 

--- a/client/index.js
+++ b/client/index.js
@@ -32,23 +32,23 @@ const key = curry((type, payload) =>
 
 const sox = (args = {}) => {
   const {
+    clientOptions = {},
     query = Function.prototype,
-    uri   = '',
-    options = {}
+    uri   = ''
   } = args
 
   const session = { session: cuid() }
   const url     = URL.parse(uri)
   const base    = URL.format(pick(['protocol', 'slashes', 'host'], url))
 
-  const opts = {
+  const options = {
     autoConnect: false,
     path: url.pathname,
     query: merge(session, query())
   }
 
-  const getOptions = compose(merge(opts), pick(ALLOWED_OPTIONS))
-  const socket = io(base, getOptions(options))
+  const extraOptions = pick(ALLOWED_OPTIONS, clientOptions)
+  const socket = io(base, merge(extraOptions, options))
 
   const connect = bind(socket.connect, socket)
 


### PR DESCRIPTION
## Description
Want to ability to pass options to the `socket.io-client` upon creation.  Examples of those options is specified here, and will remain optional.  https://socket.io/docs/client-api/

