### PR TITLE
Bumping funky to 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 [![@articulate/sox](https://img.shields.io/npm/v/@articulate/sox.svg)](https://www.npmjs.com/package/@articulate/sox)
 [![Build Status](https://travis-ci.org/articulate/sox.svg?branch=master)](https://travis-ci.org/articulate/sox)
 [![Coverage Status](https://coveralls.io/repos/github/articulate/sox/badge.svg?branch=master)](https://coveralls.io/github/articulate/sox?branch=master)
-[![NSP Status](https://nodesecurity.io/orgs/articulate/projects/4cf8d77e-4275-42d3-b2a4-8c2e1fa790d4/badge)](https://nodesecurity.io/orgs/articulate/projects/4cf8d77e-4275-42d3-b2a4-8c2e1fa790d4)
 
 Our super-special sockets stuff.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@articulate/sox",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Our super-special sockets stuff",
   "browser": "dist/index.js",
   "main": "server/index.js",
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@articulate/ducks": "^0.1.0",
-    "@articulate/funky": "^1.0.1",
+    "@articulate/funky": "^2.0.0",
     "boom": "^7.2.0",
     "crocks": "^0.10.1",
     "cuid": "^2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8,9 +8,10 @@
   dependencies:
     crocks "^0.7.0"
 
-"@articulate/funky@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@articulate/funky/-/funky-1.0.1.tgz#f54c6d18d259a091b85cafdde4229f2b50ca4547"
+"@articulate/funky@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@articulate/funky/-/funky-2.0.0.tgz#462791050461125f3dc5d2a45e46e70d272a9bd0"
+  integrity sha512-lwMJC6rgPs3UTn/0GCsW1Dg74OngU74phVBMgzd2njgALeMsmIuGMjFCPlVttjmaUzRd3xI24p0UOVFZcH8IbQ==
   dependencies:
     ramda "^0.25.0"
 


### PR DESCRIPTION
The big changes for funky 2.0.0 was changes to the combine* functions. Since this repo does not use any of funky's combine functions, we are good to upgrade to funky 2.0.0.

Additionally, it doesn't seem like the NSP Status badge we were using exists anymore (it was acquired by NPM), so I removed it.