### PR TITLE
Update boom to @hapi/boom to fix a high-severity vulnerability

### DIFF
--- a/.changeset/wet-bobcats-fold.md
+++ b/.changeset/wet-bobcats-fold.md
@@ -1,0 +1,5 @@
+---
+"@articulate/sox": minor
+---
+
+Updates boom to @hapi/boom to fix a high-severity vulnerability caused by the hoek dependency (GHSA-c429-5p7v-vgjp)

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@articulate/ducks": "^0.1.0",
     "@articulate/funky": "^2.0.0",
-    "boom": "^7.2.0",
+    "@hapi/boom": "^7.4.11",
     "crocks": "^0.10.1",
     "cuid": "^2.1.1",
     "ramda": "^0.25.0",

--- a/server/fromError.js
+++ b/server/fromError.js
@@ -1,4 +1,4 @@
-const { boomify, badRequest } = require('boom')
+const { boomify, badRequest } = require('@hapi/boom')
 const { converge, identity, pipe, prop, unless, when } = require('ramda')
 
 const formatError = err => {

--- a/test/handle.js
+++ b/test/handle.js
@@ -1,5 +1,5 @@
 const { action }   = require('@articulate/ducks')
-const Boom         = require('boom')
+const Boom         = require('@hapi/boom')
 const { expect }   = require('chai')
 const property     = require('prop-factory')
 const spy          = require('@articulate/spy')

--- a/yarn.lock
+++ b/yarn.lock
@@ -222,6 +222,18 @@
     human-id "^1.0.2"
     prettier "^2.7.1"
 
+"@hapi/boom@^7.4.11":
+  version "7.4.11"
+  resolved "https://registry.yarnpkg.com/@hapi/boom/-/boom-7.4.11.tgz#37af8417eb9416aef3367aa60fa04a1a9f1fc262"
+  integrity sha512-VSU/Cnj1DXouukYxxkes4nNJonCnlogHvIff1v1RVoN4xzkKhMXX+GRmb3NyH1iar10I9WFPDv2JPwfH3GaV0A==
+  dependencies:
+    "@hapi/hoek" "8.x.x"
+
+"@hapi/hoek@8.x.x":
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-8.5.1.tgz#fde96064ca446dec8c55a8c2f130957b070c6e06"
+  integrity sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow==
+
 "@manypkg/find-root@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@manypkg/find-root/-/find-root-1.1.0.tgz#a62d8ed1cd7e7d4c11d9d52a8397460b5d4ad29f"
@@ -528,12 +540,6 @@ boom@5.x.x:
   resolved "https://registry.yarnpkg.com/boom/-/boom-5.2.0.tgz#5dd9da6ee3a5f302077436290cb717d3f4a54e02"
   dependencies:
     hoek "4.x.x"
-
-boom@^7.2.0:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/boom/-/boom-7.2.0.tgz#2bff24a55565767fde869ec808317eb10c48e966"
-  dependencies:
-    hoek "5.x.x"
 
 brace-expansion@^1.1.7:
   version "1.1.8"


### PR DESCRIPTION
Fixes this high-severity vulnerability:
https://github.com/advisories/GHSA-c429-5p7v-vgjp

This new version will be used in [360-dashboard](https://github.com/articulate/360-dashboard/pull/3465).